### PR TITLE
Add missing paths to webpack config

### DIFF
--- a/lib/gobierto_gencat_engine/railtie.rb
+++ b/lib/gobierto_gencat_engine/railtie.rb
@@ -13,6 +13,7 @@ else
         conf.engine_sass_config_overrides += ["themes/conf/_theme-gencat-conf"]
         conf.engine_sass_theme_dependencies += ["themes/_theme-gencat"]
       end
+      Webpacker::Compiler.watched_paths << "app/javascript/gencat/**/*.js"
     end
   end
 end


### PR DESCRIPTION
**How to test this**

In `staging01`:

```bash
cd /var/www/gobierto_staging/current
bundle exec rails assets:precompile # => Nothing should change
vim /var/www/gobierto_staging/current/vendor/gobierto_engines/gobierto-gencat-engine/app/javascripts/gencat/modules/gp_gencat_welcome_controller.js # => Modify a console.log
bundle exec rails assets:precompile # => Compilation should be triggered
touch tmp/restart.txt
# visit http://gencat.gobify.net/cargos-y-agendas and check the updated message appears in the console
```