### PR TITLE
Fix turbolinks cache issue with back button

### DIFF
--- a/app/javascripts/gencat/modules/application.js
+++ b/app/javascripts/gencat/modules/application.js
@@ -6,9 +6,9 @@ $(document).on('turbolinks:load', function() {
 
   window.GobiertoPeople.gencat_common_controller.load(commonControllerLoadArgs);
 
-  window.GobiertoPeople.gencat_common_controller.updatePageHeader(
-    commonControllerUpdatePageHeaderArgs
-  );
+  window.GobiertoPeople.gencat_common_controller.updatePageHeader({
+    pageTitle: $("meta[name='page_title']").attr("content")
+  });
 
   if (currentLocationMatches('welcome_index')) {
     window.GobiertoPeople.gencat_map_controller.index(mapControllerIndexParams);

--- a/app/views/gobierto_people/layouts/application.html.erb
+++ b/app/views/gobierto_people/layouts/application.html.erb
@@ -2,6 +2,8 @@
   <link rel="stylesheet" href="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   <script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js"></script>
 
+  <meta name="page_title" content="<%= raw (@meta_tags ? @meta_tags['title'] : nil) %>">
+
   <%= javascript_tag do %>
     commonControllerLoadArgs = {
       people_events_first_date: '<%= all_start_date.try(:iso8601) %>',
@@ -9,9 +11,6 @@
       people_events_filter_end_date: '<%= filter_end_date.try(:iso8601) %>'
     }
 
-    commonControllerUpdatePageHeaderArgs = {
-      pageTitle: "<%= raw (@meta_tags ? @meta_tags['title'] : nil) %>"
-    }
   <% end %>
 <% end %>
 


### PR DESCRIPTION
For testing, check this steps:

1. Visit people home http://gencat.gobify.net/personas?start_date=2018-06-01
2. Click in any person, the header should update
3. Click the back button, the header should update