### PR TITLE
Remove webpacker watched_paths from engine railtie

### DIFF
--- a/lib/gobierto_gencat_engine/railtie.rb
+++ b/lib/gobierto_gencat_engine/railtie.rb
@@ -13,7 +13,6 @@ else
         conf.engine_sass_config_overrides += ["themes/conf/_theme-gencat-conf"]
         conf.engine_sass_theme_dependencies += ["themes/_theme-gencat"]
       end
-      Webpacker::Compiler.watched_paths << "app/javascript/gencat/**/*.js"
     end
   end
 end


### PR DESCRIPTION
This PR removes a deprecated watched_paths Webpacker configuration in engine railtie which is not required because the Capistrano recipe runs for each engine a `create_webpacker_symlinks.sh` script adding the dependencies with a symlink under Gobierto paths