### PR TITLE
Use cache_service in cached parts

### DIFF
--- a/app/views/gobierto_people/people/gifts/index.html.erb
+++ b/app/views/gobierto_people/people/gifts/index.html.erb
@@ -12,7 +12,7 @@
   <% if @person_gifts.any? %>
 
     <ul class="color-4 transparent">
-      <% cache "#{cache_key_preffix}-gifts" do %>
+      <% cache_service.fetch("#{cache_key_preffix}-gifts") do %>
         <% @person_gifts.each do |gift| %>
           <%= render "gift", gift: gift %>
         <% end %>

--- a/app/views/gobierto_people/people/invitations/index.html.erb
+++ b/app/views/gobierto_people/people/invitations/index.html.erb
@@ -12,7 +12,7 @@
   <% if @person_invitations.any? %>
 
     <ul class="color-3 transparent">
-      <% cache "#{cache_key_preffix}-invitations" do %>
+      <% cache_service.fetch("#{cache_key_preffix}-invitations") do %>
         <% @person_invitations.each do |invitation| %>
           <%= render "invitation", invitation: invitation %>
         <% end %>

--- a/app/views/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_people/people/person_events/index.html.erb
@@ -12,7 +12,7 @@
   <% if @events.any? %>
 
     <ul class="color-1 transparent">
-      <% cache "#{cache_key_preffix}-events" do %>
+      <% cache_service.fetch("#{cache_key_preffix}-events") do %>
         <% @events.each do |event| %>
           <%= render "event", event: event %>
         <% end %>

--- a/app/views/gobierto_people/people/trips/index.html.erb
+++ b/app/views/gobierto_people/people/trips/index.html.erb
@@ -12,7 +12,7 @@
   <% if @person_trips.any? && trips_submodule_active? %>
 
     <ul class="color-2 transparent">
-      <% cache "#{cache_key_preffix}-trips" do %>
+      <% cache_service.fetch("#{cache_key_preffix}-trips") do %>
         <% @person_trips.each do |trip| %>
           <%= render "trip", trip: trip %>
         <% end %>


### PR DESCRIPTION
Related to PopulateTools/issues#1532


This PR makes use of the cache_service helper method provided by the base controller of GobiertoPeople module for currently cached fragments on views