### PR TITLE
Fix cache_service use in views

### DIFF
--- a/app/views/gobierto_people/people/gifts/index.html.erb
+++ b/app/views/gobierto_people/people/gifts/index.html.erb
@@ -12,7 +12,7 @@
   <% if @person_gifts.any? %>
 
     <ul class="color-4 transparent">
-      <% cache_service.fetch("#{cache_key_preffix}-gifts") do %>
+      <% cache_service_fragment("#{cache_key_preffix}-gifts") do %>
         <% @person_gifts.each do |gift| %>
           <%= render "gift", gift: gift %>
         <% end %>

--- a/app/views/gobierto_people/people/invitations/index.html.erb
+++ b/app/views/gobierto_people/people/invitations/index.html.erb
@@ -12,7 +12,7 @@
   <% if @person_invitations.any? %>
 
     <ul class="color-3 transparent">
-      <% cache_service.fetch("#{cache_key_preffix}-invitations") do %>
+      <% cache_service_fragment("#{cache_key_preffix}-invitations") do %>
         <% @person_invitations.each do |invitation| %>
           <%= render "invitation", invitation: invitation %>
         <% end %>

--- a/app/views/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_people/people/person_events/index.html.erb
@@ -12,7 +12,7 @@
   <% if @events.any? %>
 
     <ul class="color-1 transparent">
-      <% cache_service.fetch("#{cache_key_preffix}-events") do %>
+      <% cache_service_fragment("#{cache_key_preffix}-events") do %>
         <% @events.each do |event| %>
           <%= render "event", event: event %>
         <% end %>

--- a/app/views/gobierto_people/people/trips/index.html.erb
+++ b/app/views/gobierto_people/people/trips/index.html.erb
@@ -12,7 +12,7 @@
   <% if @person_trips.any? && trips_submodule_active? %>
 
     <ul class="color-2 transparent">
-      <% cache_service.fetch("#{cache_key_preffix}-trips") do %>
+      <% cache_service_fragment("#{cache_key_preffix}-trips") do %>
         <% @person_trips.each do |trip| %>
           <%= render "trip", trip: trip %>
         <% end %>


### PR DESCRIPTION
On views the cache_service uses a fragment cache helper method instead of cache_service directly. This PR fixes the usage