### PR TITLE
Update language selector partial to be used in layout

### DIFF
--- a/app/views/gobierto_people/shared/_locales.html.erb
+++ b/app/views/gobierto_people/shared/_locales.html.erb
@@ -10,7 +10,7 @@
     <img class="NG-rotate-image NG-navbar__image NG-navbar__image--float-right" src="https://web.gencat.cat/web/resources/fwkResponsive/fpca_capcalera/img/chevron-down-thin-b.svg" alt="">
   </a>
   <ul class="NG-navbar__list-language idioma" aria-label="<% t(".page_locale") %>">
-    <% (%w(ca es) - [I18n.locale.to_s]).each do |locale| %>
+    <% %w(ca es).each do |locale| %>
       <% locale_tr = t(locale, scope: "locales") %>
 
       <li class="NG-block__content"><a title="<%= locale_tr %>" data-idioma="<%= locale_tr %>" lang="es" role="button" tabindex="0" class="js-NG-idioma-item js-NG-idioma-tooltip NG-block__content_label notranslate enllacIdioma" href="<%= url_for(locale: locale, only_path: true) %>"><%= locale_tr %></a></li>

--- a/app/views/gobierto_people/shared/_locales.html.erb
+++ b/app/views/gobierto_people/shared/_locales.html.erb
@@ -13,7 +13,11 @@
     <% %w(ca es).each do |locale| %>
       <% locale_tr = t(locale, scope: "locales") %>
 
-      <li class="NG-block__content"><a title="<%= locale_tr %>" data-idioma="<%= locale_tr %>" lang="es" role="button" tabindex="0" class="js-NG-idioma-item js-NG-idioma-tooltip NG-block__content_label notranslate enllacIdioma" href="<%= url_for(locale: locale, only_path: true) %>"><%= locale_tr %></a></li>
+      <li class="NG-block__content">
+        <a title="<%= locale_tr %>" data-idioma="<%= locale_tr %>" lang="es" role="button" tabindex="0" class="js-NG-idioma-item js-NG-idioma-tooltip NG-block__content_label notranslate enllacIdioma" href="<%= url_for(locale: locale, only_path: true) %>" data-turbolinks="false">
+          <%= locale_tr %>
+        </a>
+      </li>
     <% end %>
   </ul>
 </li>

--- a/app/views/gobierto_people/shared/_locales.html.erb
+++ b/app/views/gobierto_people/shared/_locales.html.erb
@@ -1,2 +1,19 @@
-<%= link_to "ca", url_for(locale: "ca", only_path: true), title: "Català" %>
-<%= link_to "es", url_for(locale: "es", only_path: true), title: "Castellano" %>
+<li class="NG-navbar__list NG-navbar__list--vertical-sm">
+  <a class="NG-navbar__link js-NG-menu-idioma" id="rotate_icon" role="button" aria-expanded="false" title="<%= t(".select_locale") %>" tabindex="0">
+    <img class="NG-navbar__image" src="https://web.gencat.cat/web/resources/fwkResponsive/fpca_capcalera/img/idioma-b.svg" alt="">
+    <span class="NG-idioma">
+      <%= t(".locale") %>:</span>
+    <span class="NG-nom-idioma-letter">
+      <span class="js-NG-idioma-text notranslate"><%= I18n.locale %></span>
+      <img class="NG-navbar__down" src="https://web.gencat.cat/web/resources/fwkResponsive/fpca_capcalera/img/chevron-down-small-w.svg" alt="">
+    </span>
+    <img class="NG-rotate-image NG-navbar__image NG-navbar__image--float-right" src="https://web.gencat.cat/web/resources/fwkResponsive/fpca_capcalera/img/chevron-down-thin-b.svg" alt="">
+  </a>
+  <ul class="NG-navbar__list-language idioma" aria-label="<% t(".page_locale") %>">
+    <% (%w(ca es) - [I18n.locale.to_s]).each do |locale| %>
+      <% locale_tr = t(locale, scope: "locales") %>
+
+      <li class="NG-block__content"><a title="<%= locale_tr %>" data-idioma="<%= locale_tr %>" lang="es" role="button" tabindex="0" class="js-NG-idioma-item js-NG-idioma-tooltip NG-block__content_label notranslate enllacIdioma" href="<%= url_for(locale: locale, only_path: true) %>"><%= locale_tr %></a></li>
+    <% end %>
+  </ul>
+</li>

--- a/config/locales/gobierto_people/views/ca.yml
+++ b/config/locales/gobierto_people/views/ca.yml
@@ -141,6 +141,10 @@ ca:
       displacement: desplaçament
       displacements: desplaçaments
       from: de
+      locales:
+        locale: Idioma
+        page_locale: Idioma de la pàgina
+        select_locale: Selecciona idioma
       meetings_punchcard:
         tooltip: reunions
         tooltip_single: reunió

--- a/config/locales/gobierto_people/views/en.yml
+++ b/config/locales/gobierto_people/views/en.yml
@@ -128,6 +128,10 @@ en:
       displacement: displacement
       displacements: displacements
       from: from
+      locales:
+        locale: Language
+        page_locale: Page locale
+        select_locale: Select language
       meetings_punchcard:
         tooltip: meetings
         tooltip_single: meeting

--- a/config/locales/gobierto_people/views/es.yml
+++ b/config/locales/gobierto_people/views/es.yml
@@ -134,6 +134,10 @@ es:
       displacement: desplazamiento
       displacements: desplazamientos
       from: de
+      locales:
+        locale: Idioma
+        page_locale: Idioma de la página
+        select_locale: Selecciona idioma
       meetings_punchcard:
         tooltip: reuniones
         tooltip_single: reunión


### PR DESCRIPTION
Fixes PopulateTools/issues#1949

This PR updates the language selector used by the layout of GenCat. The resullt can be checked in https://gencat.gobify.net/ca/departments/departament-d-accio-exterior-i-unio-europea?page=false&start_date=2018-06-01

After merging this in production and deploy update the layout template from admin with the same as used in staging.