### PR TITLE
Restore module GobiertoPeople

### DIFF
--- a/app/javascripts/gencat/modules/application.js
+++ b/app/javascripts/gencat/modules/application.js
@@ -2,6 +2,10 @@ function currentLocationMatches(controller_action) {
   return $("body.gobierto_people." + controller_action).length > 0
 }
 
+window.GobiertoPeople = {
+  init: function() {}
+};
+
 $(document).on('turbolinks:load', function() {
 
   window.GobiertoPeople.gencat_common_controller.load(commonControllerLoadArgs);


### PR DESCRIPTION
This module was removed in the main app, but it's still used in the engine.

This is the easy patch, the real solution should be refactor to remove it.

I think the reason we didn't notice this error in staging is because the deploy has been a bit stuck these day sin the staging server, otherwise I don't understand, because the missing module error is clear.