### PR TITLE
Fix function to use override the URL in the href attribute

### DIFF
--- a/app/javascripts/gencat/modules/gp_gencat_common_controller.js
+++ b/app/javascripts/gencat/modules/gp_gencat_common_controller.js
@@ -72,7 +72,8 @@ function loadBreadcrumb() {
 
 function appendDateRangeToLocaleLinks() {
   $(".idioma li a").each(function(index) {
-    this.href = appendDateRangeParamsToUrl(document.location.pathname, document.location.href);
+    const url = new URL(this.href);
+    this.href = appendDateRangeParamsToUrl(url.pathname, document.location.href);
   });
 }
 


### PR DESCRIPTION
This PR fixes the wrong override of paths of locales selector of layout